### PR TITLE
Removed a multiplication by 100

### DIFF
--- a/lib/src/url/cached_pdf_view.dart
+++ b/lib/src/url/cached_pdf_view.dart
@@ -66,7 +66,7 @@ class CachedPDFView extends StatelessWidget {
           return errorWidget!(snapshot.error);
         } else if (loading) {
           final double progress =
-              (((snapshot.data as DownloadProgress?)?.progress ?? 0) * 100)
+              ((snapshot.data as DownloadProgress?)?.progress ?? 0)
                   .roundToDouble();
           return placeholder!(progress);
         } else {


### PR DESCRIPTION
Before: The download's progress has been multiplied by `100`

Resulting bug: The default download progress indicator (a `CircularProgressIndicator`) is always displaying a state of `100%` downloaded, since the range any (Flutter-default) progress indicator ([CircularProgressIndicator](https://api.flutter.dev/flutter/material/CircularProgressIndicator-class.html) and [LinearProgressIndicator](https://api.flutter.dev/flutter/material/LinearProgressIndicator-class.html)) uses a value range of `0` to `1`. Therefore, by multiplying with `100`, the visual progress indication is lost.

This has now been fixed.